### PR TITLE
fix(address-lookup): fix NaN when concatenating number without extension

### DIFF
--- a/.changeset/fix-address-lookup-concatenate-extension-nan.md
+++ b/.changeset/fix-address-lookup-concatenate-extension-nan.md
@@ -1,0 +1,10 @@
+---
+'@form-wizard-framework/address-lookup': patch
+'@form-wizard-framework/eslint-config': patch
+---
+
+Fix NaN when concatenating number with absent extension in postcode address lookup.
+
+When `concatenateExtension` is true and an address has no extension (e.g. a stored address returned by the API), the extension key was deleted before concatenation, causing `number + undefined = NaN`. The fix coerces the number to a string and treats a missing extension as an empty string.
+
+The shared ESLint config is also bumped from `es2018` to `es2020` to allow nullish coalescing (`??`), consistent with the Node >=24 engine requirement.

--- a/packages/adress-lookup/lib/nl/postcode-api/mixin.js
+++ b/packages/adress-lookup/lib/nl/postcode-api/mixin.js
@@ -125,7 +125,8 @@ module.exports = (Controller) =>
             const extensionKey = fieldName + '-' + EXTENSION_PART_KEY;
             const numberKey = fieldName + '-' + NUMBER_PART_KEY;
 
-            values[numberKey] = values[numberKey] + values[extensionKey];
+            values[numberKey] =
+              String(values[numberKey] ?? '') + (values[extensionKey] ?? '');
 
             delete values[extensionKey];
           }

--- a/packages/adress-lookup/test/lib/nl/postcode-api/mixin.spec.js
+++ b/packages/adress-lookup/test/lib/nl/postcode-api/mixin.spec.js
@@ -316,6 +316,34 @@ describe('Postcode API address lookup mixin', () => {
       });
     });
 
+    it('should not produce NaN when concatenating a number without an extension', () => {
+      BaseController.prototype.getValues = jest
+        .fn()
+        .mockImplementation((req, res, cb) => {
+          cb(null, {
+            address1: {
+              postcode: '2517KC',
+              number: 8, // integer, as returned by the postcode API
+              // no extension key
+            },
+          });
+        });
+
+      req.form.options.addressLookup.concatenateExtension = true;
+
+      return new Promise((resolve, reject) => {
+        instance.getValues(req, res, (err, values) => {
+          if (err) return reject(err);
+          try {
+            expect(values['address1-number']).toBe('8');
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+    });
+
     it('can concatenate the number with extension', () => {
       BaseController.prototype.getValues = jest
         .fn()

--- a/packages/eslint-config/.eslintrc.js
+++ b/packages/eslint-config/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   env: {
     node: true,
-    es2018: true,
+    es2020: true,
   },
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   rules: {


### PR DESCRIPTION
Closes #18

## Summary

- When `concatenateExtension` is true and a stored address has no extension, `getValues` deleted the extension key before concatenation, resulting in `number + undefined = NaN` (integer house numbers returned by the API are not strings)
- Fix: coerce number to string and treat a missing extension as `''`
- Also bumps the shared ESLint config env from `es2018` → `es2020` to permit nullish coalescing (`??`), consistent with the `engines: { node: ">=24" }` requirement

## Test plan

- [x] New failing test added to reproduce the bug (`should not produce NaN when concatenating a number without an extension`)
- [x] All 57 tests pass
- [x] ESLint passes